### PR TITLE
Fixes problem when multi_node is false. 

### DIFF
--- a/lib/capistrano/node.rb
+++ b/lib/capistrano/node.rb
@@ -67,7 +67,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
 
     desc 'Symlink node version'
     task :symlink_node do
-      exit unless multi_node
+      next unless multi_node
 
       unless node_version
         puts red('No suitable node version found')


### PR DESCRIPTION
Fixes problem described in
https://github.com/flowdock/capistrano-node/issues/1

It is preferable to use exit instead of return here.
